### PR TITLE
Increased stress duration from 30m to 60m

### DIFF
--- a/applystress.yaml
+++ b/applystress.yaml
@@ -14,4 +14,4 @@ spec:
     cpu:
       workers: 2
       load: 100
-  duration: 30m
+  duration: 60m


### PR DESCRIPTION
We observed DevOps Guru takes around 25min to raise the kubernetes pod CPU utilization insight. When we see the insight, even if the incident is already solved, DG shows the insight as on going instead of closed. We expect to make this scenario coherent by increasing the stress duration from 30m to 60m. The insight will still be on going as the stress is still on going.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
